### PR TITLE
Handle empty array for shadowsocks.dnsServers

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -53,10 +53,8 @@ spec:
                   key: {{ .existingSecret.passwordKey }}
             {{- end }}
             {{- end }}
-            {{- with .Values.shadowsocks.dnsServers }}
             - name: DNS_ADDRS
-              value: {{ join "," . }}
-            {{- end }}
+              value: {{ .Values.shadowsocks.dnsServers | join "," | quote }}
             {{- with .Values.shadowsocks.timeout }}
             - name: TIMEOUT
               value: {{ quote . }}


### PR DESCRIPTION
This PR makes sure that an empty array `[]` for the value of `shadowsocks.dnsServers` will create an empty `DNS_ADDRS` environment variable.